### PR TITLE
Replace all occurences of '0/1' text with 'off/on'

### DIFF
--- a/src/drivers/dingux-sdl/gui/control_settings.cpp
+++ b/src/drivers/dingux-sdl/gui/control_settings.cpp
@@ -204,7 +204,7 @@ int RunControlSettings()
 				{
 					int mergeValue;
 					g_config->getOption("SDL.MergeControls", &mergeValue);
-					sprintf(cBtn, "%d", mergeValue);
+					sprintf(cBtn, "%s", mergeValue ? "on" : "off");
 				}
 				else if (iBtnVal == DefaultGamePad[0][0])
 					sprintf(cBtn, "%s", "GCW_A");

--- a/src/drivers/dingux-sdl/gui/main_settings.cpp
+++ b/src/drivers/dingux-sdl/gui/main_settings.cpp
@@ -236,8 +236,10 @@ int RunMainSettings() {
 					else
 						strncpy(tmp, palname.substr(path_sz + 1, sz - 1
 								- path_sz).c_str(), 32);
-				} else
+				} else if (!strncmp(st_menu[i].name, "Mouse speed", 11)) {
 					sprintf(tmp, "%d", itmp);
+				} else
+					sprintf(tmp, "%s", itmp ? "on" : "off");
 				DrawText(gui_screen, tmp, 210, y);
 			}
 

--- a/src/drivers/dingux-sdl/gui/sound_settings.cpp
+++ b/src/drivers/dingux-sdl/gui/sound_settings.cpp
@@ -235,8 +235,12 @@ int RunSoundSettings() {
 				DrawText(gui_screen, sd_menu[i].name, 60, y);
 
 				g_config->getOption(sd_menu[i].option, &itmp);
-				sprintf(tmp, "%d", itmp);
 
+				if (!strncmp(sd_menu[i].name, "Toggle sound", 12) \
+				|| !strncmp(sd_menu[i].name, "Lowpass", 7)) {
+					sprintf(tmp, "%s", itmp ? "on" : "off");
+				} else
+					sprintf(tmp, "%d", itmp);
 				DrawText(gui_screen, tmp, 210, y);
 			}
 

--- a/src/drivers/dingux-sdl/gui/video_settings.cpp
+++ b/src/drivers/dingux-sdl/gui/video_settings.cpp
@@ -183,7 +183,12 @@ int RunVideoSettings()
 				g_config->getOption(vd_menu[i].option, &itmp);
 				if (!strncmp(vd_menu[i].name, "Video scaling", 5)) {
 					sprintf(tmp, "%s", scale_tag[itmp]);
-				} 
+				}
+				else if (!strncmp(vd_menu[i].name, "Clip sides", 10) \
+					|| !strncmp(vd_menu[i].name, "New PPU", 7)   \
+					|| !strncmp(vd_menu[i].name, "NTSC Palette", 12)) {
+					sprintf(tmp, "%s", itmp ? "on" : "off");
+				}
 				else sprintf(tmp, "%d", itmp);
 
 				DrawText(gui_screen, tmp, 210, y);


### PR DESCRIPTION
Using "off/on" text strings in the options menu is easier for people to understand.